### PR TITLE
Fix compile fail under linux

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <string.h>
+#ifdef __APPLE__
 #include <MacTypes.h>
+#else
+#define false 0
+#endif
 
 #include "commands.h"
 #include "known_hosts_file.h"


### PR DESCRIPTION
There is no MacTypes.h on Linux.
The only type used by known_hosts is 'false', so defined it to fix this issue