### PR TITLE
Added fix for out of bounds index values

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -11,10 +11,15 @@
 #include "config.h"
 #include "display.h"
 
-void extract_host_from_string(char *host, char *line) {
+int extract_host_from_string(char *host, char *line) {
     size_t index = strchr(line, ' ') - line;
+    if (index > 128) {
+            printf("Index out of bounds for host: %s - Skipping\n", host);
+            return 128;
+    }
     strncpy(host, line, index);
     host[index] = '\0';
+    return 0;
 }
 
 void commands_ls_hosts() {


### PR DESCRIPTION
In funtion extract_host_from_string() index will get 18446603338992386848 as a value when the below line is passed.
Added return value if this happens and print the offending host line
The following `known_hosts` line segfaults `known_hosts ls`

|1|AQgsieloMUkxeO4xVLVTRuedHDU=|KBxAm1pcRFmO8ls41HXYwShxkx8= ssh-dss
AAAAB3NzaC1kc3MAAAEBANE8I9ZtttoI+RfTPTPUdbfSh1EaMoL7XgpxF1msZiBwuOL+W5jFmTtyTyBFpcMW2eyuVLkNaUGu8LQRsiFGCKawlpBIuE+AY2vvcwp5ufD1gJUY8c0JQ3iqEZRjg/R043uq31UZSmHFihCb77Q+Zf2BqSOTR4MceuvOjv5u/twyXzi6iuAWZaisdBenCEEW1U+rj59DMRkH5TDw2FIVCv11MUst+clBfysM6EWMcDDZVXeB+zPraWlVe0I0uvBpwR1MXZxCWJTfBEzssbYpe7NzJkePzi4071j70L7DSt2+oCPj58xClG/vvwqJF/LvAEhqgjjS4PD5WObxIhKYsM0AAAAVAM8h7qBgAhC2ITz+HsY6VC/vrbWDAAABAQCEI3oxXHlWyeVkoQoVNGgEV2B46uwPdw39jCf+XEKA9lXdKXt+cXUwxa+qhDvKp78ulqHVjYewVl0CYD0+9c+oPlZyQIv/SDGd1MLutZuj3lyIOvv8H1pVZCaqr6GmWUOhCwY+2AwOrpSH75DUMwJOkCScSuDT7WRNxROLJOpEVcAgrrajEQcXxO4zf4U9qvY/akG6X4PQgm2Z2221c5gxbUMiec9GNsMKMUPzG5vUrtF5ehQx26y/GuaiTxmxUsif6pO3T1cjPzXn5AtqMyah9RgiRWyG92GXHwY1b9x67wwkDPlC7MHjXCJxB2F9BT+iAxPDDjrABAFnAGWe1nrnAAABAEMX1q1aVB1pG2GKWn7BKCniAvaZPhG0qovxfmvwFpZyrpYSS+X+koM/RH4WsLmRVIuh1vs+XcuVBqTkyAlrkIovxhrYsL7TtKf/5xnarGOqm+1RYJN5iFc5Bn9ZJ3PARKdDgIRaranYT/V96lRo6ZTJbKHEz50orIVdtFRku5LJoDEBVqfD39EdEGYJJihA+nKwhIYDs6PrpEcxG+NWxpUBf3UfkQMr9JXah/f9GvCRddpOeaq2x0qwyfO0/4dRWSZ1L2F0dDySGxMdsNDbpBO49OoUj2tQFI+9AQR5X4P9WmHEAB4FPQQPAYRwuppb656nYyvPhPImXrHGqPqSgb0=